### PR TITLE
[TEAM-05][BE-B] 2주차 PR

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -30,7 +30,16 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	// Jasypt
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+	// Oauth 통신에 필요한 WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// jwt 라이브러리
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/be/src/main/java/kr/codesquad/secondhand/SecondHandApplication.java
+++ b/be/src/main/java/kr/codesquad/secondhand/SecondHandApplication.java
@@ -2,12 +2,14 @@ package kr.codesquad.secondhand;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SecondHandApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SecondHandApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(SecondHandApplication.class, args);
+    }
 
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/controller/CategoryController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/controller/CategoryController.java
@@ -1,0 +1,23 @@
+package kr.codesquad.secondhand.api.category.controller;
+
+import java.util.List;
+import kr.codesquad.secondhand.api.category.dto.CategoryResponse;
+import kr.codesquad.secondhand.api.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("api/categories")
+    public ResponseEntity<List<CategoryResponse>> getCategories() {
+        List<CategoryResponse> categoryResponses = categoryService.getCategories();
+        return ResponseEntity.ok()
+                .body(categoryResponses);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/domain/Category.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/domain/Category.java
@@ -1,0 +1,21 @@
+package kr.codesquad.secondhand.api.category.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String imgUrl;
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategoryResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategoryResponse.java
@@ -1,0 +1,21 @@
+package kr.codesquad.secondhand.api.category.dto;
+
+import kr.codesquad.secondhand.api.category.domain.Category;
+import lombok.Getter;
+
+@Getter
+public class CategoryResponse {
+    private Long id;
+    private String name;
+    private String imgUrl;
+
+    public CategoryResponse(Long id, String name, String imgUrl) {
+        this.id = id;
+        this.name = name;
+        this.imgUrl = imgUrl;
+    }
+
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(category.getId(), category.getName(), category.getImgUrl());
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/repository/CategoryRepositoryImpl.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/repository/CategoryRepositoryImpl.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.api.category.repository;
+
+import kr.codesquad.secondhand.api.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepositoryImpl extends JpaRepository<Category, Long> {
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/service/CategoryService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/service/CategoryService.java
@@ -1,0 +1,23 @@
+package kr.codesquad.secondhand.api.category.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.category.domain.Category;
+import kr.codesquad.secondhand.api.category.dto.CategoryResponse;
+import kr.codesquad.secondhand.api.category.repository.CategoryRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepositoryImpl categoryRepository;
+
+    public List<CategoryResponse> getCategories() {
+        List<Category> categories = categoryRepository.findAll();
+        return categories.stream()
+                .map(CategoryResponse::from)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/config/JwtProperties.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/config/JwtProperties.java
@@ -1,0 +1,18 @@
+package kr.codesquad.secondhand.api.jwt.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+
+    private String secretKey;
+    private Long accessTokenExpirationTime;
+    private Long refreshTokenExpirationTime;
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/Jwt.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/Jwt.java
@@ -1,0 +1,13 @@
+package kr.codesquad.secondhand.api.jwt.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Jwt {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/MemberRefreshToken.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/MemberRefreshToken.java
@@ -1,0 +1,23 @@
+package kr.codesquad.secondhand.api.jwt.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "token")
+public class MemberRefreshToken {
+
+    @Id
+    private Long memberId;
+
+    private String refreshToken;
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/repository/TokenRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/repository/TokenRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.jwt.repository;
+
+import kr.codesquad.secondhand.api.jwt.domain.MemberRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TokenRepository extends JpaRepository<MemberRefreshToken, Long> {
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
@@ -1,0 +1,36 @@
+package kr.codesquad.secondhand.api.jwt.service;
+
+import java.util.Collections;
+import kr.codesquad.secondhand.api.jwt.domain.Jwt;
+import kr.codesquad.secondhand.api.jwt.domain.MemberRefreshToken;
+import kr.codesquad.secondhand.api.jwt.repository.TokenRepository;
+import kr.codesquad.secondhand.api.jwt.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private static final String MEMBER_ID = "memberId";
+
+    private final JwtProvider jwtProvider;
+    private final TokenRepository tokenRepository;
+
+    @Transactional
+    public Jwt issueJwt(Long memberId) {
+        Jwt jwt = jwtProvider.createTokens(Collections.singletonMap(MEMBER_ID, memberId));
+        if (tokenRepository.existsById(memberId)) {
+            tokenRepository.deleteById(memberId);
+        }
+        tokenRepository.save(new MemberRefreshToken(memberId, jwt.getRefreshToken()));
+        return jwt;
+    }
+
+    public String reissueAccessToken() {
+        // TODO
+        return null;
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/util/JwtProvider.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/util/JwtProvider.java
@@ -1,0 +1,64 @@
+package kr.codesquad.secondhand.api.jwt.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import kr.codesquad.secondhand.api.jwt.config.JwtProperties;
+import kr.codesquad.secondhand.api.jwt.domain.Jwt;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private Key key;
+
+    @PostConstruct
+    private void setKey() {
+        key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+    }
+
+    public Jwt createTokens(Map<String, Object> claims) {
+        String accessToken = createToken(claims, getAccessTokenExpireDate());
+        String refreshToken = createToken(new HashMap<>(), getRefreshTokenExpireDate());
+        return new Jwt(accessToken, refreshToken);
+    }
+
+    private String createToken(Map<String, Object> claims, Date expiration) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expiration)
+                .signWith(key)
+                .compact();
+    }
+
+    public Jwt reissueAccessToken(Map<String, Object> claims, String refreshToken) {
+        String accessToken = createToken(claims, getAccessTokenExpireDate());
+        return new Jwt(accessToken, refreshToken);
+    }
+
+    private Date getAccessTokenExpireDate() {
+        return new Date(System.currentTimeMillis() + jwtProperties.getAccessTokenExpirationTime());
+    }
+
+    private Date getRefreshTokenExpireDate() {
+        return new Date(System.currentTimeMillis() + jwtProperties.getRefreshTokenExpirationTime());
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package kr.codesquad.secondhand.api.member.controller;
+
+import kr.codesquad.secondhand.api.member.dto.OAuthSignInRequest;
+import kr.codesquad.secondhand.api.member.dto.OAuthSignInResponse;
+import kr.codesquad.secondhand.api.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * 로그인 요청
+     */
+    @PostMapping("/api/members/sign-in/{provider}")
+    public ResponseEntity<OAuthSignInResponse> login(@PathVariable String provider,
+                                                     @RequestBody OAuthSignInRequest request) {
+        OAuthSignInResponse OAuthSignInResponse = memberService.signInOrSignUp(provider, request.getAccessCode());
+        return ResponseEntity.ok()
+                .body(OAuthSignInResponse);
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/domain/Address.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/domain/Address.java
@@ -1,0 +1,22 @@
+package kr.codesquad.secondhand.api.member.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/domain/Member.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/domain/Member.java
@@ -1,0 +1,47 @@
+package kr.codesquad.secondhand.api.member.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String nickname;
+    private String profileImgUrl;
+
+    @CreatedDate
+    private LocalDateTime createdTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sign_in_type_id")
+    private SignInType signInType;
+
+    @Builder
+    public Member(SignInType signInType, String email, String nickname, String profileImgUrl) {
+        this.signInType = signInType;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/domain/MemberAddress.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/domain/MemberAddress.java
@@ -1,0 +1,38 @@
+package kr.codesquad.secondhand.api.member.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAddress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "address_id")
+    private Address address;
+
+    private boolean isLastVisited;
+
+    public MemberAddress(Member member, Address address, boolean isLastVisited) {
+        this.member = member;
+        this.address = address;
+        this.isLastVisited = isLastVisited;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/domain/SignInType.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/domain/SignInType.java
@@ -1,0 +1,22 @@
+package kr.codesquad.secondhand.api.member.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignInType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String provider;
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/dto/OAuthSignInRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/dto/OAuthSignInRequest.java
@@ -1,0 +1,12 @@
+package kr.codesquad.secondhand.api.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OAuthSignInRequest {
+
+    // Oauth 서버 인증용 Authorization Code
+    private String accessCode;
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/dto/OAuthSignInResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/dto/OAuthSignInResponse.java
@@ -1,0 +1,68 @@
+package kr.codesquad.secondhand.api.member.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.jwt.domain.Jwt;
+import kr.codesquad.secondhand.api.member.domain.Address;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.member.domain.MemberAddress;
+import lombok.Getter;
+
+@Getter
+public class OAuthSignInResponse {
+
+    private final Jwt tokens;
+    private final List<MemberAddressResponse> addresses;
+    private final MemberSignInResponse member;
+
+    public OAuthSignInResponse(Jwt tokens, List<MemberAddressResponse> memberAddresses,
+                               MemberSignInResponse memberSignInResponse) {
+        this.tokens = tokens;
+        this.addresses = memberAddresses;
+        this.member = memberSignInResponse;
+    }
+
+    public static OAuthSignInResponse of(Jwt jwt, List<MemberAddress> memberAddress, Member member) {
+        List<MemberAddressResponse> memberAddressResponses =
+                memberAddress.stream()
+                        .map(MemberAddressResponse::from)
+                        .collect(Collectors.toUnmodifiableList());
+        MemberSignInResponse memberSignInResponse = MemberSignInResponse.from(member);
+        return new OAuthSignInResponse(jwt, memberAddressResponses, memberSignInResponse);
+    }
+
+    @Getter
+    public static class MemberAddressResponse {
+
+        private final Long id;
+        private final String name;
+        private final boolean isLastVisited;
+
+        public MemberAddressResponse(Long id, String name, boolean isLastVisited) {
+            this.id = id;
+            this.name = name;
+            this.isLastVisited = isLastVisited;
+        }
+
+        public static MemberAddressResponse from(MemberAddress memberAddress) {
+            Address address = memberAddress.getAddress();
+            return new MemberAddressResponse(address.getId(), address.getName(), memberAddress.isLastVisited());
+        }
+    }
+
+    @Getter
+    public static class MemberSignInResponse {
+
+        private final String nickName;
+        private final String profileImgUrl;
+
+        public MemberSignInResponse(String nickName, String profileImgUrl) {
+            this.nickName = nickName;
+            this.profileImgUrl = profileImgUrl;
+        }
+
+        public static MemberSignInResponse from(Member member) {
+            return new MemberSignInResponse(member.getNickname(), member.getProfileImgUrl());
+        }
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/AddressRepositoryImpl.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/AddressRepositoryImpl.java
@@ -1,0 +1,9 @@
+package kr.codesquad.secondhand.api.member.repository;
+
+import kr.codesquad.secondhand.api.member.domain.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AddressRepositoryImpl extends JpaRepository<Address, Long> {
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/JpaMemberRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/JpaMemberRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.member.repository;
+
+import java.util.Optional;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findBySignInTypeIdAndEmail(Long signInTypeId, String email);
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberAddressRepositoryImpl.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberAddressRepositoryImpl.java
@@ -1,0 +1,11 @@
+package kr.codesquad.secondhand.api.member.repository;
+
+import java.util.List;
+import java.util.Optional;
+import kr.codesquad.secondhand.api.member.domain.MemberAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberAddressRepositoryImpl extends JpaRepository<MemberAddress, Long> {
+
+    Optional<List<MemberAddress>> findAllByMemberId(Long memberId);
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepository.java
@@ -9,4 +9,5 @@ public interface MemberRepository {
 
     Optional<Member> findBySignInTypeIdAndEmail(Long signInTypeId, String email);
 
+    Member getReferenceById(Long id);
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package kr.codesquad.secondhand.api.member.repository;
+
+import java.util.Optional;
+import kr.codesquad.secondhand.api.member.domain.Member;
+
+public interface MemberRepository {
+
+    Long save(Member member);
+
+    Optional<Member> findBySignInTypeIdAndEmail(Long signInTypeId, String email);
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepositoryImpl.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,26 @@
+package kr.codesquad.secondhand.api.member.repository;
+
+import java.util.Optional;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final JpaMemberRepository repository;
+
+    @Override
+    public Long save(Member member) {
+        return repository.save(member).getId();
+    }
+
+    @Override
+    public Optional<Member> findBySignInTypeIdAndEmail(Long signInTypeId, String email) {
+        return repository.findBySignInTypeIdAndEmail(signInTypeId, email);
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepositoryImpl.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/MemberRepositoryImpl.java
@@ -23,4 +23,8 @@ public class MemberRepositoryImpl implements MemberRepository {
         return repository.findBySignInTypeIdAndEmail(signInTypeId, email);
     }
 
+    public Member getReferenceById(Long id){
+        return repository.getReferenceById(id);
+    }
+
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/repository/SignInTypeRepositoryImpl.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/repository/SignInTypeRepositoryImpl.java
@@ -1,0 +1,11 @@
+package kr.codesquad.secondhand.api.member.repository;
+
+import kr.codesquad.secondhand.api.member.domain.SignInType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SignInTypeRepositoryImpl extends JpaRepository<SignInType, Long> {
+
+    SignInType findByProvider(String provider);
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberService.java
@@ -1,0 +1,60 @@
+package kr.codesquad.secondhand.api.member.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import kr.codesquad.secondhand.api.jwt.domain.Jwt;
+import kr.codesquad.secondhand.api.jwt.service.JwtService;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.member.domain.MemberAddress;
+import kr.codesquad.secondhand.api.member.domain.SignInType;
+import kr.codesquad.secondhand.api.member.dto.OAuthSignInResponse;
+import kr.codesquad.secondhand.api.member.repository.MemberAddressRepositoryImpl;
+import kr.codesquad.secondhand.api.member.repository.MemberRepository;
+import kr.codesquad.secondhand.api.member.repository.SignInTypeRepositoryImpl;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthProfile;
+import kr.codesquad.secondhand.api.oauth.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final OAuthService oAuthService;
+    private final JwtService jwtService;
+
+    private final SignInTypeRepositoryImpl signInTypeRepository;
+    private final MemberRepository memberRepository;
+    private final MemberAddressRepositoryImpl memberAddressRepository;
+
+    @Transactional
+    public OAuthSignInResponse signInOrSignUp(String providerName, String authorizationCode) {
+        OAuthProfile oAuthProfile = oAuthService.requestOauthProfile(providerName, authorizationCode);
+        SignInType signInType = signInTypeRepository.findByProvider(
+                providerName); // TODO: 메모리 저장소에 캐싱해두고 사용할 수 있게 개선하는 방법 고민중
+        Member member = oAuthProfile.toMember(signInType);
+
+        // DB에 회원 저장 유무 판단
+        Optional<Member> findMember = memberRepository.findBySignInTypeIdAndEmail(
+                member.getSignInType().getId(),
+                member.getEmail()
+        );
+
+        if (findMember.isEmpty()) {
+            memberRepository.save(member);
+            return signIn(member);
+        }
+        return signIn(findMember.get());
+    }
+
+    private OAuthSignInResponse signIn(Member member) {
+        Jwt jwt = jwtService.issueJwt(member.getId());
+        Optional<List<MemberAddress>> memberAddress = memberAddressRepository.findAllByMemberId(member.getId());
+        if (memberAddress.isPresent()) {
+            return OAuthSignInResponse.of(jwt, memberAddress.get(), member);
+        }
+        return OAuthSignInResponse.of(jwt, new ArrayList<>(), member);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberService.java
@@ -57,4 +57,8 @@ public class MemberService {
         }
         return OAuthSignInResponse.of(jwt, new ArrayList<>(), member);
     }
+
+    public Member getMemberReferenceById(Long memberId){
+        return memberRepository.getReferenceById(memberId);
+    }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/config/OAuthConfig.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/config/OAuthConfig.java
@@ -1,0 +1,25 @@
+package kr.codesquad.secondhand.api.oauth.config;
+
+import java.util.Map;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthRegistration;
+import kr.codesquad.secondhand.api.oauth.repository.OAuthRegistrationRepository;
+import kr.codesquad.secondhand.api.oauth.util.OAuthPropertiesRegistrationAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OAuthProperties.class)
+@RequiredArgsConstructor
+public class OAuthConfig {
+
+    private final OAuthProperties properties;
+
+    @Bean
+    public OAuthRegistrationRepository oauthRegistrationRepository() {
+        Map<String, OAuthRegistration> registrations =
+                OAuthPropertiesRegistrationAdapter.getOauthRegistrations(properties);
+        return new OAuthRegistrationRepository(registrations);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/config/OAuthProperties.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/config/OAuthProperties.java
@@ -1,0 +1,33 @@
+package kr.codesquad.secondhand.api.oauth.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * yml 설정 파일과 바인딩되는 객체
+ */
+@Getter
+@ConfigurationProperties(prefix = "oauth2")
+public class OAuthProperties {
+
+    private final Map<String, Client> client = new HashMap<>();
+    private final Map<String, Provider> provider = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class Client {
+        private String clientId;
+        private String clientSecret;
+        private String redirectUri;
+    }
+
+    @Getter
+    @Setter
+    public static class Provider {
+        private String tokenRequestUri;
+        private String userInfoRequestUri;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthAttributes.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthAttributes.java
@@ -1,0 +1,44 @@
+package kr.codesquad.secondhand.api.oauth.domain;
+
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Oauth 서버별 OauthProfile 정보를 갖고 있는 Enum 클래스
+ */
+@RequiredArgsConstructor
+public enum OAuthAttributes {
+
+    GITHUB("github") {
+        @Override
+        public OAuthProfile of(Map<String, Object> attributes) {
+            return OAuthProfile.builder()
+                    .email((String) attributes.get("email"))
+                    .name((String) attributes.get("login"))
+                    .imageUrl((String) attributes.get("avatar_url"))
+                    .build();
+        }
+    },
+    KAKAO("kakao") {
+        @Override
+        public OAuthProfile of(Map<String, Object> attributes) {
+            Map<String, Object> info = (Map<String, Object>) attributes.get("kakao_account");
+            Map<String, Object> profile = (Map<String, Object>) info.get("profile");
+            return OAuthProfile.builder()
+                    .email((String) info.get("email"))
+                    .name((String) profile.get("nickname"))
+                    .imageUrl((String) profile.get("profile_image_url"))
+                    .build();
+        }
+    };
+
+    @Getter
+    public final String providerName;
+
+    public abstract OAuthProfile of(Map<String, Object> attributes);
+
+    public static boolean isGithub(String providerName){
+        return GITHUB.providerName.equals(providerName);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthProfile.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthProfile.java
@@ -1,0 +1,43 @@
+package kr.codesquad.secondhand.api.oauth.domain;
+
+import java.util.Arrays;
+import java.util.Map;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.member.domain.SignInType;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Oauth 리소스 서버의 유저 정보와 바인딩되는 객체
+ */
+@Getter
+public class OAuthProfile {
+
+    private final String email;
+    private final String name;
+    private final String imageUrl;
+
+    @Builder
+    public OAuthProfile(String email, String name, String imageUrl) {
+        this.email = email;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+
+    public static OAuthProfile of(String providerName, Map<String, Object> attributes) {
+        return Arrays.stream(OAuthAttributes.values())
+                .filter(provider -> providerName.equals(provider.providerName))
+                .findFirst()
+                .orElseThrow() // TODO: 예외처리
+                .of(attributes);
+    }
+
+    public Member toMember(SignInType signInType) {
+        return Member.builder()
+                .signInType(signInType)
+                .email(email)
+                .nickname(name)
+                .profileImgUrl(imageUrl)
+                .build();
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthRegistration.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthRegistration.java
@@ -1,0 +1,36 @@
+package kr.codesquad.secondhand.api.oauth.domain;
+
+import kr.codesquad.secondhand.api.oauth.config.OAuthProperties;
+import kr.codesquad.secondhand.api.oauth.config.OAuthProperties.Client;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * OauthProperties의 app-info와 provider의 provider별로 필드를 합친 클래스
+ */
+@Getter
+public class OAuthRegistration {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+    private final String tokenRequestUri;
+    private final String userInfoRequestUri;
+
+    public OAuthRegistration(Client client, OAuthProperties.Provider provider) {
+        this(client.getClientId(), client.getClientSecret(), client.getRedirectUri(),
+                provider.getTokenRequestUri(), provider.getUserInfoRequestUri()
+        );
+    }
+
+    @Builder
+    public OAuthRegistration(String clientId, String clientSecret, String redirectUri,
+                             String tokenUri, String userInfoUri) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+        this.tokenRequestUri = tokenUri;
+        this.userInfoRequestUri = userInfoUri;
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/dto/OAuthTokenResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/dto/OAuthTokenResponse.java
@@ -1,0 +1,26 @@
+package kr.codesquad.secondhand.api.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OAuthTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @Builder
+    public OAuthTokenResponse(String accessToken, String scope, String tokenType) {
+        this.accessToken = accessToken;
+        this.scope = scope;
+        this.tokenType = tokenType;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/repository/OAuthRegistrationRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/repository/OAuthRegistrationRepository.java
@@ -1,0 +1,15 @@
+package kr.codesquad.secondhand.api.oauth.repository;
+
+import java.util.Map;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthRegistration;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OAuthRegistrationRepository {
+
+    private final Map<String, OAuthRegistration> registrations;
+
+    public OAuthRegistration findByProviderName(String name) {
+        return registrations.get(name);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/service/OAuthService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/service/OAuthService.java
@@ -1,0 +1,96 @@
+package kr.codesquad.secondhand.api.oauth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthAttributes;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthProfile;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthRegistration;
+import kr.codesquad.secondhand.api.oauth.dto.OAuthTokenResponse;
+import kr.codesquad.secondhand.api.oauth.repository.OAuthRegistrationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final OAuthRegistrationRepository oauthRegistrationRepository;
+    private final String GITHUB_REQUEST_PRIVATE_EMAIL_URI = "https://api.github.com/user/emails";
+
+    public OAuthProfile requestOauthProfile(String providerName, String authorizationCode) {
+        // repository에서 providerName과 일치하는 registration 가져오기
+        OAuthRegistration registration = oauthRegistrationRepository.findByProviderName(providerName);
+
+        // Oauth 인증 서버에 token 요청
+        OAuthTokenResponse tokenResponse = requestToken(authorizationCode, registration);
+
+        // Oauth 리소스 서버에 유저 정보 요청
+        Map<String, Object> attributes = requestOauthAttributes(registration, tokenResponse);
+
+        if (OAuthAttributes.isGithub(providerName) && attributes.get("email") == null) {
+            attributes.put("email", getGithubPrivateEmail(tokenResponse).get(0).get("email"));
+        }
+        return OAuthProfile.of(providerName, attributes);
+    }
+
+    /**
+     * Oauth 인증 서버에 token을 요청하는 메서드
+     */
+    private OAuthTokenResponse requestToken(String authorizationCode, OAuthRegistration registration) {
+        return WebClient.create()
+                .post()
+                .uri(registration.getTokenRequestUri())
+                .headers(header -> {
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(tokenRequestBodyData(authorizationCode, registration))
+                .retrieve()
+                .bodyToMono(OAuthTokenResponse.class)
+                .block();
+    }
+
+    private MultiValueMap<String, String> tokenRequestBodyData(String authorizationCode, OAuthRegistration provider) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", authorizationCode);
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", provider.getClientId());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("redirect_uri", provider.getRedirectUri());
+        return formData;
+    }
+
+    /**
+     * OAuth 리소스 서버에 유저 정보를 요청하는 메서드
+     */
+    private Map<String, Object> requestOauthAttributes(OAuthRegistration registration,
+                                                       OAuthTokenResponse tokenResponse) {
+        return WebClient.create()
+                .get()
+                .uri(registration.getUserInfoRequestUri())
+                .headers(header -> header.setBearerAuth(tokenResponse.getAccessToken()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+    }
+
+    public List<Map<String, Object>> getGithubPrivateEmail(OAuthTokenResponse tokenResponse) {
+        return WebClient.create()
+                .get()
+                .uri(GITHUB_REQUEST_PRIVATE_EMAIL_URI)
+                .headers(header -> header.setBearerAuth(tokenResponse.getAccessToken()))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {
+                })
+                .block();
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/util/OAuthPropertiesRegistrationAdapter.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/util/OAuthPropertiesRegistrationAdapter.java
@@ -1,0 +1,23 @@
+package kr.codesquad.secondhand.api.oauth.util;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.oauth.config.OAuthProperties;
+import kr.codesquad.secondhand.api.oauth.domain.OAuthRegistration;
+
+/**
+ * Spring Security의 OAuth2ClientPropertiesRegistrationAdapter 역할 : OauthProperties를 OauthRegistration으로 변환
+ */
+public class OAuthPropertiesRegistrationAdapter {
+
+    public static Map<String, OAuthRegistration> getOauthRegistrations(OAuthProperties properties) {
+        return properties.getClient().entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, // provider name
+                        entry -> new OAuthRegistration(
+                                entry.getValue(), // app-info 값(client-id, client-secret, redirect-url)
+                                properties.getProvider().get(entry.getKey()) // providers map의 value 값(token-url, user-info-url)
+                        )
+                ));
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/config/S3Config.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/config/S3Config.java
@@ -1,0 +1,35 @@
+package kr.codesquad.secondhand.api.product.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
@@ -1,0 +1,27 @@
+package kr.codesquad.secondhand.api.product.controller;
+
+import java.io.IOException;
+import kr.codesquad.secondhand.api.product.dto.ProductCreateRequest;
+import kr.codesquad.secondhand.api.product.dto.ProductCreateResponse;
+import kr.codesquad.secondhand.api.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @PostMapping("/api/products")
+    public ResponseEntity<ProductCreateResponse> uploads3(@ModelAttribute ProductCreateRequest productCreateRequest)
+            throws IOException {
+        //TODO 인증 필터 구현 시 토큰에서 memberId 받아올 예정
+        Long memberId = 1L;
+        ProductCreateResponse productCreateResponse = productService.save(productCreateRequest, memberId);
+        return ResponseEntity.ok().body(productCreateResponse);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
@@ -3,10 +3,14 @@ package kr.codesquad.secondhand.api.product.controller;
 import java.io.IOException;
 import kr.codesquad.secondhand.api.product.dto.ProductCreateRequest;
 import kr.codesquad.secondhand.api.product.dto.ProductCreateResponse;
+import kr.codesquad.secondhand.api.product.dto.ProductModifyRequest;
 import kr.codesquad.secondhand.api.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +27,12 @@ public class ProductController {
         Long memberId = 1L;
         ProductCreateResponse productCreateResponse = productService.save(productCreateRequest, memberId);
         return ResponseEntity.ok().body(productCreateResponse);
+    }
+
+    @PatchMapping("/api/products/{productId}")
+    public ResponseEntity modifyProduct(@PathVariable Long productId, @ModelAttribute
+    ProductModifyRequest productModifyRequest) throws IOException {
+        productService.modify(productId, productModifyRequest);
+        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
@@ -32,7 +32,7 @@ public class ProductController {
     @PatchMapping("/api/products/{productId}")
     public ResponseEntity modifyProduct(@PathVariable Long productId, @ModelAttribute
     ProductModifyRequest productModifyRequest) throws IOException {
-        productService.modify(productId, productModifyRequest);
+        productService.modifyProduct(productId, productModifyRequest);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/domain/Image.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/domain/Image.java
@@ -1,0 +1,34 @@
+package kr.codesquad.secondhand.api.product.domain;
+
+import java.net.URL;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "product_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private URL url;
+
+    public Image(Product product, URL url) {
+        this.product = product;
+        this.url = url;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/domain/Product.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/domain/Product.java
@@ -1,0 +1,71 @@
+package kr.codesquad.secondhand.api.product.domain;
+
+import java.net.URL;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import kr.codesquad.secondhand.api.category.domain.Category;
+import kr.codesquad.secondhand.api.member.domain.Address;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id")
+    private Member seller;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_id")
+    private ProductStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id")
+    private Address address;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    private String title;
+    private String content;
+    private Long price;
+
+    @CreationTimestamp
+    private Date createdTime;
+    private URL thumbnailImgUrl;
+
+    @Builder
+    public Product(Member seller, ProductStatus status, Address address, Category category, String title,
+                   String content,
+                   Long price, Date createdTime, URL thumbnailImgUrl) {
+        this.seller = seller;
+        this.status = status;
+        this.address = address;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.createdTime = createdTime;
+        this.thumbnailImgUrl = thumbnailImgUrl;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/domain/Product.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/domain/Product.java
@@ -13,6 +13,7 @@ import javax.persistence.ManyToOne;
 import kr.codesquad.secondhand.api.category.domain.Category;
 import kr.codesquad.secondhand.api.member.domain.Address;
 import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.product.dto.ProductModifyRequest;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -66,6 +67,16 @@ public class Product {
         this.content = content;
         this.price = price;
         this.createdTime = createdTime;
+        this.thumbnailImgUrl = thumbnailImgUrl;
+    }
+
+    public void updateProduct(ProductModifyRequest productModifyRequest, Address address, Category category,
+                              URL thumbnailImgUrl) {
+        this.title = productModifyRequest.getTitle();
+        this.content = productModifyRequest.getContent();
+        this.price = productModifyRequest.getPrice();
+        this.address = address;
+        this.category = category;
         this.thumbnailImgUrl = thumbnailImgUrl;
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/domain/ProductStatus.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/domain/ProductStatus.java
@@ -1,0 +1,20 @@
+package kr.codesquad.secondhand.api.product.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "product_status")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String type;
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductCreateRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductCreateRequest.java
@@ -1,0 +1,38 @@
+package kr.codesquad.secondhand.api.product.dto;
+
+import java.net.URL;
+import java.util.List;
+import kr.codesquad.secondhand.api.category.domain.Category;
+import kr.codesquad.secondhand.api.member.domain.Address;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.product.domain.Product;
+import kr.codesquad.secondhand.api.product.domain.ProductStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@RequiredArgsConstructor
+public class ProductCreateRequest {
+
+    private final Long categoryId;
+    private final Long addressId;
+    private final String title;
+    private final String content;
+    private final Long price;
+    private final List<MultipartFile> images;
+
+    public Product toEntity(Member seller, ProductStatus status, Address address, Category category,
+                            URL thumbnailImgUrl) {
+        return Product.builder()
+                .seller(seller)
+                .thumbnailImgUrl(thumbnailImgUrl)
+                .category(category)
+                .status(status)
+                .address(address)
+                .title(title)
+                .content(content)
+                .price(price)
+                .build();
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductCreateResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductCreateResponse.java
@@ -1,0 +1,12 @@
+package kr.codesquad.secondhand.api.product.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProductCreateResponse {
+    Long productId;
+
+    public ProductCreateResponse(Long productId) {
+        this.productId = productId;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductModifyRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductModifyRequest.java
@@ -1,0 +1,27 @@
+package kr.codesquad.secondhand.api.product.dto;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+public class ProductModifyRequest {
+    private final Long categoryId;
+    private final Long addressId;
+    private final String title;
+    private final String content;
+    private final Long price;
+    private final List<MultipartFile> newImages;
+    private final List<Integer> deletedImgIds;
+
+    public ProductModifyRequest(Long categoryId, Long addressId, String title, String content, Long price,
+                                List<MultipartFile> newImages, List<Integer> deletedImgIds) {
+        this.categoryId = categoryId;
+        this.addressId = addressId;
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.newImages = newImages;
+        this.deletedImgIds = deletedImgIds;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/repository/ImageRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/repository/ImageRepository.java
@@ -1,7 +1,16 @@
 package kr.codesquad.secondhand.api.product.repository;
 
+import java.net.URL;
+import java.util.List;
 import kr.codesquad.secondhand.api.product.domain.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    List<Image> findAllByProductId(Long ProductId);
+
+    @Query(value = "select i.url from product_image i where i.product_id = ?1 order by id asc limit 1", nativeQuery = true)
+    URL findMinByProductId(Long productId);
+
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/repository/ImageRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package kr.codesquad.secondhand.api.product.repository;
+
+import kr.codesquad.secondhand.api.product.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/repository/ProductRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package kr.codesquad.secondhand.api.product.repository;
+
+import kr.codesquad.secondhand.api.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/repository/StatusRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/repository/StatusRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.product.repository;
+
+import kr.codesquad.secondhand.api.product.domain.ProductStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StatusRepository extends JpaRepository<ProductStatus, Long> {
+    ProductStatus getReferenceByType(String type);
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/service/ImageService.java
@@ -1,0 +1,77 @@
+package kr.codesquad.secondhand.api.product.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.product.domain.Image;
+import kr.codesquad.secondhand.api.product.domain.Product;
+import kr.codesquad.secondhand.api.product.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final AmazonS3 amazonS3;
+    private final ImageRepository imageRepository;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public void saveAll(List<URL> imageUrls, Product product) {
+        List<Image> images = imageUrlsToImage(imageUrls, product);
+        imageRepository.saveAll(images);
+    }
+
+    public List<URL> uploadMultiImagesToS3(List<MultipartFile> multipartFiles) throws IOException {
+        List<URL> urls = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFiles) {
+            urls.add(uploadSingleImageToS3(multipartFile));
+        }
+        return urls;
+    }
+
+    private URL uploadSingleImageToS3(MultipartFile multipartFile) throws IOException {
+        String uuid = UUID.randomUUID().toString(); // 이미지 이름 중복 방지를 위한 고유한 이미지 이름 생성
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+        amazonS3.putObject(bucket, uuid, multipartFile.getInputStream(), metadata);
+        return amazonS3.getUrl(bucket, uuid);
+    }
+
+    public List<Image> imageUrlsToImage(List<URL> imageUrls, Product product) {
+        return imageUrls.stream()
+                .map(imageUrl -> new Image(product, imageUrl))
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public URL updateImageUrls(Product product, List<MultipartFile> newImages, List<Integer> deletedImageIds)
+            throws IOException {
+
+        if (!newImages.isEmpty()) {
+            List<Image> newImageEntities = imageUrlsToImage(uploadMultiImagesToS3(newImages), product);
+            imageRepository.saveAll(newImageEntities);
+        }
+
+        List<Image> images = imageRepository.findAllByProductId(product.getId());
+        if (deletedImageIds != null) {
+            List<Long> deleteImgIds = deletedImageIds.stream()
+                    .map(deleteId -> images.get(deleteId).getId())
+                    .collect(Collectors.toUnmodifiableList());
+            imageRepository.deleteAllById(deleteImgIds);
+        }
+        return getThumbnailImgUrl(product.getId());
+    }
+
+    private URL getThumbnailImgUrl(Long productId) {
+        return imageRepository.findMinByProductId(productId);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/service/ProductService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/service/ProductService.java
@@ -1,32 +1,26 @@
 package kr.codesquad.secondhand.api.product.service;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import kr.codesquad.secondhand.api.category.domain.Category;
 import kr.codesquad.secondhand.api.category.repository.CategoryRepositoryImpl;
 import kr.codesquad.secondhand.api.member.domain.Address;
 import kr.codesquad.secondhand.api.member.domain.Member;
 import kr.codesquad.secondhand.api.member.repository.AddressRepositoryImpl;
 import kr.codesquad.secondhand.api.member.service.MemberService;
-import kr.codesquad.secondhand.api.product.domain.Image;
 import kr.codesquad.secondhand.api.product.domain.Product;
 import kr.codesquad.secondhand.api.product.domain.ProductStatus;
 import kr.codesquad.secondhand.api.product.dto.ProductCreateRequest;
 import kr.codesquad.secondhand.api.product.dto.ProductCreateResponse;
-import kr.codesquad.secondhand.api.product.repository.ImageRepository;
+import kr.codesquad.secondhand.api.product.dto.ProductModifyRequest;
 import kr.codesquad.secondhand.api.product.repository.ProductRepository;
 import kr.codesquad.secondhand.api.product.repository.StatusRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +32,7 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final AddressRepositoryImpl addressRepository;
     private final CategoryRepositoryImpl categoryRepository;
-    private final ImageRepository imageRepository;
+    private final ImageService imageService;
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
@@ -46,7 +40,7 @@ public class ProductService {
     public ProductCreateResponse save(ProductCreateRequest productCreateRequest, Long memberId) throws IOException {
         //  TODO 썸네일 리사이징 기능 구현
         // 임시 썸네일 이미지
-        List<URL> imageUrls = uploadMultiImagesToS3(productCreateRequest.getImages());
+        List<URL> imageUrls = imageService.uploadMultiImagesToS3(productCreateRequest.getImages());
         URL thumbnailImgUrl = imageUrls.get(0);
         Member seller = memberService.getMemberReferenceById(memberId);
 //        id가 아닌 type으로 조회할 경우 쿼리가 발생한다. (쿼리 메소드가 아닌 인터페이스에 추가한 메소드라서?)
@@ -56,33 +50,17 @@ public class ProductService {
         Category category = categoryRepository.getReferenceById(productCreateRequest.getCategoryId());
         Product product = productCreateRequest.toEntity(seller, status, address, category, thumbnailImgUrl);
         productRepository.save(product);
-        List<Image> images = imageUrlsToImage(imageUrls, product);
-        imageRepository.saveAll(images);
+        imageService.saveAll(imageUrls, product);
         return new ProductCreateResponse(product.getId());
     }
 
-
-    // TODO: 예외 처리: 파일 없을 때, 파일 확장자가 이미지가 아닐 때(처리하면 for문 stream으로 수정)
-    private List<URL> uploadMultiImagesToS3(List<MultipartFile> multipartFiles) throws IOException {
-        List<URL> urls = new ArrayList<>();
-        for (MultipartFile multipartFile : multipartFiles) {
-            urls.add(uploadSingleImageToS3(multipartFile));
-        }
-        return urls;
-    }
-
-    private URL uploadSingleImageToS3(MultipartFile multipartFile) throws IOException {
-        String uuid = UUID.randomUUID().toString(); // 이미지 이름 중복 방지를 위한 고유한 이미지 이름 생성
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(multipartFile.getSize());
-        metadata.setContentType(multipartFile.getContentType());
-        amazonS3.putObject(bucket, uuid, multipartFile.getInputStream(), metadata);
-        return amazonS3.getUrl(bucket, uuid);
-    }
-
-    private List<Image> imageUrlsToImage(List<URL> imageUrls, Product product) {
-        return imageUrls.stream()
-                .map(imageUrl -> new Image(product, imageUrl))
-                .collect(Collectors.toUnmodifiableList());
+    @Transactional
+    public void modifyProduct(Long productId, ProductModifyRequest productModifyRequest) throws IOException {
+        Product product = productRepository.findById(productId).orElseThrow();
+        URL thumbnailImgUrl = imageService.updateImageUrls(product, productModifyRequest.getNewImages(),
+                productModifyRequest.getDeletedImgIds());
+        Address address = addressRepository.getReferenceById(productModifyRequest.getAddressId());
+        Category category = categoryRepository.getReferenceById(productModifyRequest.getCategoryId());
+        product.updateProduct(productModifyRequest, address, category, thumbnailImgUrl);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/service/ProductService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/service/ProductService.java
@@ -1,0 +1,88 @@
+package kr.codesquad.secondhand.api.product.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.category.domain.Category;
+import kr.codesquad.secondhand.api.category.repository.CategoryRepositoryImpl;
+import kr.codesquad.secondhand.api.member.domain.Address;
+import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.member.repository.AddressRepositoryImpl;
+import kr.codesquad.secondhand.api.member.service.MemberService;
+import kr.codesquad.secondhand.api.product.domain.Image;
+import kr.codesquad.secondhand.api.product.domain.Product;
+import kr.codesquad.secondhand.api.product.domain.ProductStatus;
+import kr.codesquad.secondhand.api.product.dto.ProductCreateRequest;
+import kr.codesquad.secondhand.api.product.dto.ProductCreateResponse;
+import kr.codesquad.secondhand.api.product.repository.ImageRepository;
+import kr.codesquad.secondhand.api.product.repository.ProductRepository;
+import kr.codesquad.secondhand.api.product.repository.StatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final AmazonS3 amazonS3;
+    private final MemberService memberService;
+    private final StatusRepository statusRepository;
+    private final ProductRepository productRepository;
+    private final AddressRepositoryImpl addressRepository;
+    private final CategoryRepositoryImpl categoryRepository;
+    private final ImageRepository imageRepository;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Transactional
+    public ProductCreateResponse save(ProductCreateRequest productCreateRequest, Long memberId) throws IOException {
+        //  TODO 썸네일 리사이징 기능 구현
+        // 임시 썸네일 이미지
+        List<URL> imageUrls = uploadMultiImagesToS3(productCreateRequest.getImages());
+        URL thumbnailImgUrl = imageUrls.get(0);
+        Member seller = memberService.getMemberReferenceById(memberId);
+//        id가 아닌 type으로 조회할 경우 쿼리가 발생한다. (쿼리 메소드가 아닌 인터페이스에 추가한 메소드라서?)
+//        signInType 처럼 인메모리에 캐싱할 수 있게 리팩토링 필요
+        ProductStatus status = statusRepository.getReferenceByType("판매중");
+        Address address = addressRepository.getReferenceById(productCreateRequest.getAddressId());
+        Category category = categoryRepository.getReferenceById(productCreateRequest.getCategoryId());
+        Product product = productCreateRequest.toEntity(seller, status, address, category, thumbnailImgUrl);
+        productRepository.save(product);
+        List<Image> images = imageUrlsToImage(imageUrls, product);
+        imageRepository.saveAll(images);
+        return new ProductCreateResponse(product.getId());
+    }
+
+
+    // TODO: 예외 처리: 파일 없을 때, 파일 확장자가 이미지가 아닐 때(처리하면 for문 stream으로 수정)
+    private List<URL> uploadMultiImagesToS3(List<MultipartFile> multipartFiles) throws IOException {
+        List<URL> urls = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFiles) {
+            urls.add(uploadSingleImageToS3(multipartFile));
+        }
+        return urls;
+    }
+
+    private URL uploadSingleImageToS3(MultipartFile multipartFile) throws IOException {
+        String uuid = UUID.randomUUID().toString(); // 이미지 이름 중복 방지를 위한 고유한 이미지 이름 생성
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+        amazonS3.putObject(bucket, uuid, multipartFile.getInputStream(), metadata);
+        return amazonS3.getUrl(bucket, uuid);
+    }
+
+    private List<Image> imageUrlsToImage(List<URL> imageUrls, Product product) {
+        return imageUrls.stream()
+                .map(imageUrl -> new Image(product, imageUrl))
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/global/config/FilterConfig.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/config/FilterConfig.java
@@ -1,0 +1,18 @@
+package kr.codesquad.secondhand.global.config;
+
+import kr.codesquad.secondhand.global.filter.CorsFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilter() {
+        FilterRegistrationBean<CorsFilter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new CorsFilter());
+        filterRegistrationBean.setOrder(1);
+        return filterRegistrationBean;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/global/filter/CorsFilter.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/filter/CorsFilter.java
@@ -1,0 +1,36 @@
+package kr.codesquad.secondhand.global.filter;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+public class CorsFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+            throws ServletException, IOException {
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:8080, http://localhost:5173");
+        response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+        response.setHeader(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "3600");
+        response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                "Authorization, x-requested-with, origin, content-type, accept");
+
+        if (isPreflight((HttpServletRequest) servletRequest)) {
+            return;
+        }
+        chain.doFilter(servletRequest, servletResponse);
+    }
+
+    private boolean isPreflight(HttpServletRequest servletRequest) {
+        return servletRequest.getMethod().equalsIgnoreCase(HttpMethod.OPTIONS.name());
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/global/filter/CorsFilter.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/filter/CorsFilter.java
@@ -18,7 +18,8 @@ public class CorsFilter implements Filter {
             throws ServletException, IOException {
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:8080, http://localhost:5173");
+        response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                "http://localhost:8080, http://localhost:5173, http://gaji-b.s3-website.ap-northeast-2.amazonaws.com");
         response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, PUT, PATCH, DELETE, OPTIONS");
         response.setHeader(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "3600");
         response.setHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,

--- a/be/src/main/resources/application-jwt.yml
+++ b/be/src/main/resources/application-jwt.yml
@@ -1,0 +1,5 @@
+jwt:
+  secret-key: ENC(2V+i23yEKttxVNk9aU/j85sHewoKx0LQyToDI0bW6l5b+WP3+shZYNMN0ZhKguVv)
+  access-token-expiration-time: 3600000
+  refresh-token-expiration-time: 5184000000
+

--- a/be/src/main/resources/application-oauth2.yml
+++ b/be/src/main/resources/application-oauth2.yml
@@ -1,0 +1,17 @@
+oauth2:
+  client:
+    github:
+      client-id: Iv1.cf29a87e489d2a82
+      client-secret: ENC(GeOo8HDFHjjqfSTqGvGBbv4ydRWcb/vCvV0CYkG0LCCSvGpHLt9jQAcq4I+je0vrd9Ahdmf/55w=)
+      redirect-uri: http://localhost:5173/account/auth/github
+    kakao:
+      client-id: bfea12117cfbf4ba08a81770fcb696a4
+      client-secret: ENC(BXk6vmKBJ4D2DuhF2FXaU6p4wmJcecJsW8g8EPQmCrr68BUF8iFTYVRH0wWJUmN9)
+      redirect-uri: http://localhost:5173/account/auth/kakao
+  provider:
+    github:
+      token-request-uri: https://github.com/login/oauth/access_token
+      user-info-request-uri: https://api.github.com/user
+    kakao:
+      token-request-uri: https://kauth.kakao.com/oauth/token
+      user-info-request-uri: https://kapi.kakao.com/v2/user/me

--- a/be/src/main/resources/application-prodDB.yml
+++ b/be/src/main/resources/application-prodDB.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ENC(RI9JXqG9+smAWixcK8PDMiBtiU0AYwpCg/QLuFOL++1L5z+l1Iv9XknU1hWSJd+zcb/5KEhYMblJ90CZbeO4vfI3VrouoBBxmUYdx2CMKnQZDC98awOmaheu+JZujVh6XqEiaayP2zk=)
+    username: ENC(K0uE1ed3fhkSVZn7pwU8zA==)
+    password: ENC(KDIESpDxQIwie1FjaOVqs3mtuKLV2UYV)

--- a/be/src/main/resources/application-s3.yml
+++ b/be/src/main/resources/application-s3.yml
@@ -1,0 +1,12 @@
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+      auto: false
+    s3:
+      bucket: gamgyul-bucket/public
+    credentials:
+      access-key: # Github Actions에서 추가
+      secret-key: # Github Actions에서 추가
+    stack:
+      auto: false

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,7 +1,24 @@
 spring:
   profiles:
     group:
-      stage: stageDB, jasypt
+      stage: stageDB, jasypt, oauth2, jwt
       prod:
       test:
     active: stage
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+
+# JPA Log
+logging:
+  level:
+    org:
+      hibernate:
+        sql: DEBUG
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   profiles:
     group:
-      stage: stageDB, jasypt, oauth2, jwt
+      stage: stageDB, jasypt, oauth2, jwt, s3
       prod:
       test:
     active: stage
@@ -11,6 +11,11 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 30MB
+      max-request-size: 10MB
 
 # JPA Log
 logging:

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     group:
       stage: stageDB, jasypt, oauth2, jwt, s3
-      prod:
+      prod: prodDB, jasypt, oauth2, jwt, s3
       test:
     active: stage
   jpa:

--- a/be/src/main/resources/static/index.html
+++ b/be/src/main/resources/static/index.html
@@ -1,0 +1,6 @@
+<!--authoriazation code를 얻어오기 위한 간단한 코드-->
+<a href="https://github.com/login/oauth/authorize?client_id=Iv1.cf29a87e489d2a82&scope=id,name,email,avatar_url&redirect_uri=http://13.125.12.218:8080/api/members/sign-in/github">Github
+    Login</a><br>
+<a href="https://kauth.kakao.com/oauth/authorize?client_id=bfea12117cfbf4ba08a81770fcb696a4&redirect_uri=http://13.125.12.218:8080/api/members/sign-in/kakao&response_type=code">
+    Kakao Login
+</a><br>


### PR DESCRIPTION
## 🔑 Key changes
- [x] Github, Kakao OAuth 앱을 사용하여 OAuth 토큰 발급, 개인정보 요청 기능 구현
- [x] OAuth 앱에서 받은 정보로 자체 jwt 생성 후 발급 (회원가입 / 로그인)
- [x] CORS 필터 구현
- [x] 카테고리 목록 조회 기능 구현
- [x] 상품 등록 ,수정 기능 구현

## 👋 To reviewers

안녕하세요 남세! 

회의가 많았던 저번주와 달리 이번주는 코드 구현에 치중하고자 목표를 세웠습니다.

- 2주차 마일스톤
    - 상품 CRUD
    - 카테고리 조회 API
    - 회원가입 / 로그인
    - 동네 API
    - 서버 배포
    - 테스트 코드

구현 하던 중 처음 써보는 JPA에 대한 공부, 배포에 예상치 못한 시간이 많이 들어가서  상품 R,D 동네 API, 예외 처리, 테스트 코드를 구현하지 못했습니다.

마일스톤중 JWT, OAuth, 상품 등록 기능은 코드 스타일을 맟주기 위해 페어 프로그래밍을 진행했고, 나머지 작업은 인프라 = 지니, API = 감귤 분업을 하여 구현했습니다. 

그리고 향후 목표는 처음 쓰는 기능 (채팅, JPA)들을 공부하면서 코드를 구현하고 있어서, 기능 동작에 우선 순위를 두고 API를 빨리 털어낸 다음 리팩토링을 할 계획입니다.

감사합니다 남세!!